### PR TITLE
Adds Papercall

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This file contains a list of conferences and their talk submit dates.
 
 * [Lanyrd](http://lanyrd.com/)
 * [Confreaks](http://confreaks.tv/conferences)
+* [Papercall](https://www.papercall.io/)
 * [IoT Events](https://www.iotevents.org/)
 
 #### Contributors:


### PR DESCRIPTION
Papercall aims to make it easier for speakers to find CfPs and submit proposals to conferences